### PR TITLE
Es initialisation

### DIFF
--- a/API/README.md
+++ b/API/README.md
@@ -37,6 +37,7 @@ go build ABD4/API
 ## Running du docker contenant elasticsearch 5.5.3
 ```
     cd docker-es
+    - if not exists, create dir `data` and `data2`
     - launch the docker:
         docker-compose up
     - kill the docker:

--- a/API/README.md
+++ b/API/README.md
@@ -30,7 +30,40 @@ go get github.com/gorilla/mux
 go get github.com/dgrijalva/jwt-go
 go get github.com/stretchr/testify/assert
 go get github.com/boltdb/bolt/...
+go get gopkg.in/olivere/elastic.v5
 go build ABD4/API
+```
+
+## Running du docker contenant elasticsearch 5.5.3
+```
+    cd docker-es
+    - launch the docker:
+        docker-compose up
+    - kill the docker:
+        docker-compose down [--remove-orphans, kill all instances if changes has been done in docker-compose.yml]
+```
+
+Warning: if you want to run a `local` docker set or `unset the sniffing option` of elastic library.
+```
+docker-compose.yml ->
+    services:
+        my_service:
+            environment:
+                http.publish_host=127.0.0.1
+                ...
+            ...
+        ...
+    ...
+```
+
+## Commandes Es pour voir les infos
+```
+    - voir les différents nodes (normalement 2):
+        curl http://127.0.0.1:9200/_nodes/http?pretty=1
+    - voir le cluster:
+        curl http://127.0.0.1:9200/
+    - voir le cluster health:
+        curl http://127.0.0.1:9200/_cluster/health
 ```
 
 ## Running the tests

--- a/API/context/context.go
+++ b/API/context/context.go
@@ -53,6 +53,8 @@ type IServerOption interface {
 	GetAddress() string
 	GetPort() string
 	GetIP() string
+	GetIndex() bool
+	GetReindex() bool
 }
 
 // IResponseWriter interface define the required methods to
@@ -151,6 +153,16 @@ func (ctx *AppContext) Instanciate(opts IServerOption) *AppContext {
 	if err != nil {
 		loggers.Error.Fatalf("%s %s", utils.Use().GetStack(ctx.Instanciate), err.Error())
 	}
+
+	// When Es client is up, check if we need to reindex
+	if opts.GetIndex() || opts.GetReindex() {
+		err = elasticsearch.ReIndex(ctx.ElasticClient, opts.GetReindex())
+	}
+
+	if err != nil {
+		loggers.Error.Fatalf("%s %s", utils.Use().GetStack(ctx.Instanciate), err.Error())
+	}
+
 	ctx.Log.Info.Printf("%s RootDir: %s", utils.Use().GetStack(ctx.Instanciate), ctx.Exe)
 	ctx.Log.Info.Printf("%s LogPath: %s", utils.Use().GetStack(ctx.Instanciate), ctx.Logpath)
 	ctx.Log.Info.Printf("%s Datapath: %s", utils.Use().GetStack(ctx.Instanciate), ctx.DataPath)

--- a/API/context/context.go
+++ b/API/context/context.go
@@ -15,6 +15,7 @@ package context
 
 import (
 	"ABD4/API/database/manager"
+	"ABD4/API/elasticsearch"
 	"ABD4/API/iserial"
 	"ABD4/API/logger"
 	"ABD4/API/utils"
@@ -23,6 +24,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+
+	elastic "gopkg.in/olivere/elastic.v5"
 )
 
 var (
@@ -70,14 +73,15 @@ type ISessionUser interface {
 // It embed the dao's objects (XxxManager *manager.XxxManager),
 // a ResponseWriter which offer shorthand to send uniformised Response
 type AppContext struct {
-	Rw          IResponseWriter
-	SessionUser ISessionUser
-	Opts        IServerOption
-	UserManager *manager.UserManager
-	Log         *logger.AppLogger
-	Exe         string
-	Logpath     string
-	DataPath    string
+	Rw            IResponseWriter
+	SessionUser   ISessionUser
+	Opts          IServerOption
+	UserManager   *manager.UserManager
+	Log           *logger.AppLogger
+	Exe           string
+	Logpath       string
+	DataPath      string
+	ElasticClient *elastic.Client
 }
 
 // Instanciate the global ctx variable
@@ -143,6 +147,10 @@ func (ctx *AppContext) Instanciate(opts IServerOption) *AppContext {
 	ctx.Exe = opts.GetExeFolder()
 	ctx.Logpath = opts.GetLogpath()
 	ctx.DataPath = opts.GetDatapath()
+	ctx.ElasticClient, err = elasticsearch.Instanciate()
+	if err != nil {
+		loggers.Error.Fatalf("%s %s", utils.Use().GetStack(ctx.Instanciate), err.Error())
+	}
 	ctx.Log.Info.Printf("%s RootDir: %s", utils.Use().GetStack(ctx.Instanciate), ctx.Exe)
 	ctx.Log.Info.Printf("%s LogPath: %s", utils.Use().GetStack(ctx.Instanciate), ctx.Logpath)
 	ctx.Log.Info.Printf("%s Datapath: %s", utils.Use().GetStack(ctx.Instanciate), ctx.DataPath)

--- a/API/context/context.go
+++ b/API/context/context.go
@@ -155,12 +155,16 @@ func (ctx *AppContext) Instanciate(opts IServerOption) *AppContext {
 	}
 
 	// When Es client is up, check if we need to reindex
-	if opts.GetIndex() || opts.GetReindex() {
-		err = elasticsearch.ReIndex(ctx.ElasticClient, opts.GetReindex())
-	}
-
-	if err != nil {
-		loggers.Error.Fatalf("%s %s", utils.Use().GetStack(ctx.Instanciate), err.Error())
+	if opts.GetIndex() && false == opts.GetReindex() {
+		err = elasticsearch.Index(ctx.ElasticClient)
+		if err != nil {
+			loggers.Error.Fatalf("%s %s", utils.Use().GetStack(ctx.Instanciate), err.Error())
+		}
+	} else if opts.GetReindex() {
+		err = elasticsearch.ReIndex(ctx.ElasticClient)
+		if err != nil {
+			loggers.Error.Fatalf("%s %s", utils.Use().GetStack(ctx.Instanciate), err.Error())
+		}
 	}
 
 	ctx.Log.Info.Printf("%s RootDir: %s", utils.Use().GetStack(ctx.Instanciate), ctx.Exe)

--- a/API/context/context.go
+++ b/API/context/context.go
@@ -156,12 +156,12 @@ func (ctx *AppContext) Instanciate(opts IServerOption) *AppContext {
 
 	// When Es client is up, check if we need to reindex
 	if opts.GetIndex() && false == opts.GetReindex() {
-		err = elasticsearch.Index(ctx.ElasticClient)
+		err = elasticsearch.IndexAll(ctx.ElasticClient, false)
 		if err != nil {
 			loggers.Error.Fatalf("%s %s", utils.Use().GetStack(ctx.Instanciate), err.Error())
 		}
 	} else if opts.GetReindex() {
-		err = elasticsearch.ReIndex(ctx.ElasticClient)
+		err = elasticsearch.IndexAll(ctx.ElasticClient, true)
 		if err != nil {
 			loggers.Error.Fatalf("%s %s", utils.Use().GetStack(ctx.Instanciate), err.Error())
 		}

--- a/API/context/context.go
+++ b/API/context/context.go
@@ -45,6 +45,7 @@ var (
 type IServerOption interface {
 	GetExeFolder() string
 	SetEnv(string)
+	GetEs() string
 	SetLogpath(string)
 	SetDatapath(string)
 	GetEnv() string
@@ -149,7 +150,10 @@ func (ctx *AppContext) Instanciate(opts IServerOption) *AppContext {
 	ctx.Exe = opts.GetExeFolder()
 	ctx.Logpath = opts.GetLogpath()
 	ctx.DataPath = opts.GetDatapath()
-	ctx.ElasticClient, err = elasticsearch.Instanciate()
+
+	//Define elastic serv and index if needed
+	esServ := opts.GetEs()
+	ctx.ElasticClient, err = elasticsearch.Instanciate(esServ)
 	if err != nil {
 		loggers.Error.Fatalf("%s %s", utils.Use().GetStack(ctx.Instanciate), err.Error())
 	}

--- a/API/elasticsearch/elastic.go
+++ b/API/elasticsearch/elastic.go
@@ -2,7 +2,9 @@ package elasticsearch
 
 import (
 	"ABD4/API/utils"
+	"context"
 	"fmt"
+	"io/ioutil"
 
 	elastic "gopkg.in/olivere/elastic.v5"
 )
@@ -16,4 +18,73 @@ func Instanciate() (*elastic.Client, error) {
 	}
 
 	return client, nil
+}
+
+// Index all the entities mapped in elasticsearch/esmapping/
+// TODO ajouter une boucle for sur les fichiers pour indexer.
+func Index(es *elastic.Client) error {
+	var index = "users"
+	exists, err := es.IndexExists(index).Do(context.Background())
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		err = createIndex(es, index)
+		if err != nil {
+			return err
+		}
+	}
+
+	//TODO penser à indexer depui la db pour chaque entité.
+
+	return nil
+}
+
+// ReIndex delete and create index
+// TODO: Quand on aura toutes les db il faudra faire en sorte qu'elle get tous les mappings :)
+func ReIndex(es *elastic.Client, reindex bool) error {
+	var index = "users"
+	exists, err := es.IndexExists(index).Do(context.Background())
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		deleteIndex, err := es.DeleteIndex("users").Do(context.Background())
+		if err != nil {
+			// Handle error
+			return err
+		}
+		if !deleteIndex.Acknowledged {
+			return err
+		}
+	}
+
+	err = Index(es)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//creatIndex create ES index
+func createIndex(es *elastic.Client, index string) error {
+
+	mapping, err := ioutil.ReadFile("ABD4/API/elasticsearch/esmapping/" + index + ".json")
+	if err != nil {
+		return err
+	}
+
+	mappingstr := string(mapping)
+	createIndex, err := es.CreateIndex(index).BodyString(mappingstr).Do(context.Background())
+	if err != nil {
+		return err
+	}
+	if !createIndex.Acknowledged {
+		return err
+	}
+
+	return nil
 }

--- a/API/elasticsearch/elastic.go
+++ b/API/elasticsearch/elastic.go
@@ -10,8 +10,8 @@ import (
 )
 
 // Instanciate elasticsearch client for context
-func Instanciate() (*elastic.Client, error) {
-	client, err := elastic.NewClient(elastic.SetURL("http://127.0.0.1:9200"))
+func Instanciate(serv string) (*elastic.Client, error) {
+	client, err := elastic.NewClient(elastic.SetURL("http://" + serv + ":9200"))
 	if err != nil {
 		msg := fmt.Errorf("%s elastic client Init failed: %s", utils.Use().GetStack(Instanciate), err.Error())
 		return client, msg

--- a/API/elasticsearch/elastic.go
+++ b/API/elasticsearch/elastic.go
@@ -1,0 +1,19 @@
+package elasticsearch
+
+import (
+	"ABD4/API/utils"
+	"fmt"
+
+	elastic "gopkg.in/olivere/elastic.v5"
+)
+
+// Instanciate elasticsearch client for context
+func Instanciate() (*elastic.Client, error) {
+	client, err := elastic.NewClient(elastic.SetURL("http://127.0.0.1:9200"))
+	if err != nil {
+		msg := fmt.Errorf("%s elastic client Init failed: %s", utils.Use().GetStack(Instanciate), err.Error())
+		return client, msg
+	}
+
+	return client, nil
+}

--- a/API/elasticsearch/elastic.go
+++ b/API/elasticsearch/elastic.go
@@ -20,10 +20,30 @@ func Instanciate() (*elastic.Client, error) {
 	return client, nil
 }
 
+//IndexAll launch indexation or re-indexation
+func IndexAll(es *elastic.Client, reindex bool) error {
+	files, err := ioutil.ReadDir("ABD4/API/elasticsearch/esmapping/")
+	if err != nil {
+		return err
+	}
+
+	if reindex {
+		for _, file := range files {
+			ReIndex(es, utils.NoFileExtension(file.Name()))
+		}
+	} else {
+		for _, file := range files {
+			Index(es, utils.NoFileExtension(file.Name()))
+		}
+	}
+
+	return nil
+
+}
+
 // Index all the entities mapped in elasticsearch/esmapping/
 // TODO ajouter une boucle for sur les fichiers pour indexer.
-func Index(es *elastic.Client) error {
-	var index = "users"
+func Index(es *elastic.Client, index string) error {
 	exists, err := es.IndexExists(index).Do(context.Background())
 	if err != nil {
 		return err
@@ -43,15 +63,14 @@ func Index(es *elastic.Client) error {
 
 // ReIndex delete and create index
 // TODO: Quand on aura toutes les db il faudra faire en sorte qu'elle get tous les mappings :)
-func ReIndex(es *elastic.Client) error {
-	var index = "users"
+func ReIndex(es *elastic.Client, index string) error {
 	exists, err := es.IndexExists(index).Do(context.Background())
 	if err != nil {
 		return err
 	}
 
 	if exists {
-		deleteIndex, err := es.DeleteIndex("users").Do(context.Background())
+		deleteIndex, err := es.DeleteIndex(index).Do(context.Background())
 		if err != nil {
 			// Handle error
 			return err
@@ -61,7 +80,7 @@ func ReIndex(es *elastic.Client) error {
 		}
 	}
 
-	err = Index(es)
+	err = Index(es, index)
 	if err != nil {
 		return err
 	}
@@ -77,6 +96,7 @@ func createIndex(es *elastic.Client, index string) error {
 		return err
 	}
 
+	//Casts to string for BodyString method
 	mappingstr := string(mapping)
 	createIndex, err := es.CreateIndex(index).BodyString(mappingstr).Do(context.Background())
 	if err != nil {

--- a/API/elasticsearch/elastic.go
+++ b/API/elasticsearch/elastic.go
@@ -43,7 +43,7 @@ func Index(es *elastic.Client) error {
 
 // ReIndex delete and create index
 // TODO: Quand on aura toutes les db il faudra faire en sorte qu'elle get tous les mappings :)
-func ReIndex(es *elastic.Client, reindex bool) error {
+func ReIndex(es *elastic.Client) error {
 	var index = "users"
 	exists, err := es.IndexExists(index).Do(context.Background())
 	if err != nil {

--- a/API/elasticsearch/esmapping/users.json
+++ b/API/elasticsearch/esmapping/users.json
@@ -1,0 +1,27 @@
+{
+    "settings": {
+        "number_of_shards" : 1,
+        "number_of_replicas": 0
+    },
+    "mappings" : {
+        "user":  {
+            "properties": {
+                "id": {
+                    "type": "long",
+                    "fields": {
+                        "raw": { "type": "long", "index": "not_analyzed" }
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "fields":{
+                        "raw": { "type": "string", "index": "not_analyzed" }
+                    }
+                },
+                "email": {
+                    "type": "keyword"
+                }
+            }
+        }
+    }
+}

--- a/API/handler/elastic.go
+++ b/API/handler/elastic.go
@@ -1,0 +1,26 @@
+/*
+ * File: elasticHandler.go
+ * Project: ABD4/VMD Escape Game
+ * File Created: Sunday, 30th September 2018 2:24:43 pm
+ * Author: billaud_j castel_a masera_m
+ * Contact: (billaud_j@etna-alternance.net castel_a@etna-alternance.net masera_m@etna-alternance.net)
+ * -----
+ * Last Modified: Sunday, 30th September 2018 2:36:54 pm
+ * Modified By: Aurélien Castellarnau
+ * -----
+ * Copyright © 2018 - 2018 billaud_j castel_a masera_m, ETNA - VDM EscapeGame API
+ */
+
+package handler
+
+import (
+	"ABD4/API/context"
+	"net/http"
+)
+
+// GetElasticHealth handler for Get /elastic
+func GetElasticHealth(ctx *context.AppContext, w http.ResponseWriter, r *http.Request) {
+	response := ctx.Rw.NewResponse(200, string("usersJSON"), "", "")
+	response.SendItSelf(ctx, w)
+	return
+}

--- a/API/main.go
+++ b/API/main.go
@@ -37,6 +37,8 @@ func main() {
 	var env = flag.String("env", "dev", "define environnement context, [prod|dev|test]")
 	var port = flag.Int("p", 8000, "define port")
 	var debug = flag.Bool("d", false, "active debug logging")
+	var index = flag.Bool("index", false, "indexation for ES")
+	var reindex = flag.Bool("reindex", false, "indexation with mapping reloading")
 	var logpath = flag.String("logpath", "", "define log folder path from exe folder")
 	var datapath = flag.String("datapath", "", "define data folder path from exe folder")
 	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
@@ -46,6 +48,6 @@ func main() {
 	}
 	portStr := strconv.Itoa(*port)
 	opts := &server.Option{}
-	opts.Hydrate(portStr, *ip, *env, dir, *logpath, *datapath, *debug)
+	opts.Hydrate(portStr, *ip, *env, dir, *logpath, *datapath, *debug, *index, *reindex)
 	launchApp(opts)
 }

--- a/API/main.go
+++ b/API/main.go
@@ -35,6 +35,7 @@ func launchApp(opts *server.Option) {
 func main() {
 	var ip = flag.String("ip", "0.0.0.0", "define ip address")
 	var env = flag.String("env", "dev", "define environnement context, [prod|dev|test]")
+	var es = flag.String("es", "127.0.0.1", "define the es server")
 	var port = flag.Int("p", 8000, "define port")
 	var debug = flag.Bool("d", false, "active debug logging")
 	var index = flag.Bool("index", false, "indexation for ES")
@@ -48,6 +49,6 @@ func main() {
 	}
 	portStr := strconv.Itoa(*port)
 	opts := &server.Option{}
-	opts.Hydrate(portStr, *ip, *env, dir, *logpath, *datapath, *debug, *index, *reindex)
+	opts.Hydrate(portStr, *ip, *env, *es, dir, *logpath, *datapath, *debug, *index, *reindex)
 	launchApp(opts)
 }

--- a/API/server/option.go
+++ b/API/server/option.go
@@ -22,6 +22,8 @@ type Option struct {
 	address  string
 	port     string
 	ip       string
+	index    bool
+	reindex  bool
 }
 
 var (
@@ -30,7 +32,8 @@ var (
 	TEST = "test"
 )
 
-func (o *Option) Hydrate(port, ip, env, dir, logpath, datapath string, debug bool) {
+// Hydrate set datas for Option struc
+func (o *Option) Hydrate(port, ip, env, dir, logpath, datapath string, debug bool, index bool, reindex bool) {
 	o.port = port
 	o.ip = ip
 	o.datapath = datapath
@@ -38,6 +41,8 @@ func (o *Option) Hydrate(port, ip, env, dir, logpath, datapath string, debug boo
 	o.env = env
 	o.debug = debug
 	o.exe = dir
+	o.index = index
+	o.reindex = reindex
 }
 
 // GetAddress concat ip and port and affect to address if needed
@@ -94,6 +99,16 @@ func (o *Option) GetEnv() string {
 		return DEV
 	}
 	return o.env
+}
+
+// GetIndex return if indexation is needed default false
+func (o *Option) GetIndex() bool {
+	return o.index
+}
+
+// GetReIndex return if reindexation is needed default false
+func (o *Option) GetReindex() bool {
+	return o.reindex
 }
 
 // SetEnv allow a IServerOption to change the environnement

--- a/API/server/option.go
+++ b/API/server/option.go
@@ -16,6 +16,7 @@ package server
 type Option struct {
 	exe      string
 	env      string
+	es       string
 	debug    bool
 	logpath  string
 	datapath string
@@ -33,12 +34,13 @@ var (
 )
 
 // Hydrate set datas for Option struc
-func (o *Option) Hydrate(port, ip, env, dir, logpath, datapath string, debug bool, index bool, reindex bool) {
+func (o *Option) Hydrate(port, ip, env, es, dir, logpath, datapath string, debug bool, index bool, reindex bool) {
 	o.port = port
 	o.ip = ip
 	o.datapath = datapath
 	o.logpath = logpath
 	o.env = env
+	o.es = es
 	o.debug = debug
 	o.exe = dir
 	o.index = index
@@ -101,12 +103,17 @@ func (o *Option) GetEnv() string {
 	return o.env
 }
 
+// GetEs return the es serv
+func (o *Option) GetEs() string {
+	return o.es
+}
+
 // GetIndex return if indexation is needed default false
 func (o *Option) GetIndex() bool {
 	return o.index
 }
 
-// GetReIndex return if reindexation is needed default false
+// GetReindex return if reindexation is needed default false
 func (o *Option) GetReindex() bool {
 	return o.reindex
 }

--- a/API/server/road.go
+++ b/API/server/road.go
@@ -56,9 +56,10 @@ func (r *Road) appendTo(ctx *context.AppContext, preparedHandler *context.Handle
 func GetRoadKit() map[string]RoadGetter {
 	return map[string]RoadGetter{
 		// exemple for localhost:8000/user/* set of road:
-		"/user":   getUserRouting,
-		"/auth":   getAuthRouting,
-		"/backup": getBackupRouting,
+		"/user":    getUserRouting,
+		"/auth":    getAuthRouting,
+		"/backup":  getBackupRouting,
+		"/elastic": getElasticRouting,
 	}
 }
 
@@ -114,7 +115,7 @@ func getAuthRouting() []*Road {
 		{
 			Name:            "/auth/register",
 			Method:          POST,
-			Pattern:         "register",
+			Pattern:         "/register",
 			StatusProtected: false,
 			HandlerFunc:     handler.Register,
 		},
@@ -129,6 +130,18 @@ func getBackupRouting() []*Road {
 			Pattern:         "/",
 			StatusProtected: false,
 			HandlerFunc:     handler.BackupBoltDatabase,
+		},
+	}
+}
+
+func getElasticRouting() []*Road {
+	return []*Road{
+		{
+			Name:            "/elastic",
+			Method:          GET,
+			Pattern:         "/",
+			StatusProtected: false,
+			HandlerFunc:     handler.GetElasticHealth,
 		},
 	}
 }

--- a/API/utils/utils.go
+++ b/API/utils/utils.go
@@ -15,8 +15,10 @@ package utils
 
 import (
 	"math/rand"
+	"path"
 	"reflect"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -56,4 +58,9 @@ func (u *Utils) RandStringRunes(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+//NoFileExtension trim ext from file
+func NoFileExtension(fn string) string {
+	return strings.TrimSuffix(fn, path.Ext(fn))
 }

--- a/docker-es/docker-compose.yml
+++ b/docker-es/docker-compose.yml
@@ -1,0 +1,60 @@
+version: '2'
+services:
+  elasticsearch1:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.3  #image used for the docker
+    container_name: ESABD1                                          #name of the container
+    #environment variables
+    environment:
+      - cluster.name=docker-cluster  #elasticsearch cluster  name
+      - bootstrap.memory_lock=true
+      - http.publish_host=127.0.0.1
+      - xpack.security.enabled=false    #disable identification to access ES
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:     #limit use of system-wide resources
+        nproc: 65536
+        nofile:
+            soft: 65536
+            hard: 65536
+        memlock:
+            soft: -1
+            hard: -1
+    mem_limit: 1g
+    volumes:
+      - ./data:/usr/share/elasticsearch/data #share ./data à /user/share/elasticsearch/data in the docker
+    ports:
+      - 9200:9200
+    networks:
+      - esnet
+    ###
+    ### Si on veut faire un deuxième node.. je ne pense pas que ce soit utilse pour le moment.
+    ###
+  elasticsearch2:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.3
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
+      - http.publish_host=127.0.0.1
+      - "discovery.zen.ping.unicast.hosts=ESABD1"
+    ulimits:
+        nproc: 65536
+        nofile:
+            soft: 65536
+            hard: 65536
+        memlock:
+            soft: -1
+            hard: -1
+    mem_limit: 1g
+    volumes:
+      - ./data2:/usr/share/elasticsearch/data
+    networks:
+      - esnet
+
+networks:
+  esnet:
+
+
+#   thanks to:
+#       https://github.com/olivere/elastic-with-docker
+#       https://docs.docker.com/compose/compose-file/compose-file-v2


### PR DESCRIPTION
Init d'ES:

Pour lancer le ES voir le readme sur le docker compose

pour l'API on a 2 nouvelles options qui ne sont pas totalement fonctionnelles:

--index: qui permet d'indexer les datas (permet de remettre à niveau les datas par rapport à la database)

--reindex: détruit l'index pour recréer le mapping.  (à ne faire que quand le mapping de data a changé sinon c'est chronophage pour rien).

Si ya des questions hésitez pas.